### PR TITLE
Update ChoiceMonth model to include ChoicesRemaining and ChoicesMade

### DIFF
--- a/.github/workflows/generate_release_artifacts.yml
+++ b/.github/workflows/generate_release_artifacts.yml
@@ -56,6 +56,9 @@ jobs:
           version-source: variable
           version: ${{steps.version_branch.outputs.branch_version}}
           
+      - name: Generate version from tag
+        if: ${{ github.ref_type == 'tag' }}
+
 #      - name: Debug if condition
 #        run: |
 #          echo "Tag name from steps.version_tag.outputs.major-version: ${{steps.version_tag.outputs.major-version}}"
@@ -64,7 +67,7 @@ jobs:
 #          echo "Tag name from steps.version_branch_generate.outputs.CURRENT_VERSION_MINOR: ${{steps.version_branch_generate.outputs.CURRENT_VERSION_MINOR}}"
 #          echo "Comparison evaluation: ${{ (steps.version_tag.outputs.major-version != steps.version_branch_generate.outputs.CURRENT_VERSION_MAJOR) || (steps.version_tag.outputs.minor-version != steps.version_branch_generate.outputs.CURRENT_VERSION_MINOR) }}"
       
-      - name: Set env.ARTIFACT_VERSION
+      - name: Set env.ARTIFACT_VERSION calculated from releases branch
         if: ${{ (steps.version_tag.outputs.major-version != steps.version_branch_generate.outputs.CURRENT_VERSION_MAJOR) || (steps.version_tag.outputs.minor-version != steps.version_branch_generate.outputs.CURRENT_VERSION_MINOR) }}
         id: version_artifact_setenv
         run: echo "version=${{steps.version_branch_generate.outputs.CURRENT_VERSION}}" >> $GITHUB_OUTPUT
@@ -75,6 +78,10 @@ jobs:
         run:
           echo "version=${{ steps.version_tag.outputs.current_version}}" >> $GITHUB_OUTPUT
       
+      - name: Set env.ARTIFACT_VERSION from tag
+        if: ${{github.ref_type == 'tag'}}
+        id: version_artifact_tag_setenv
+        run: echo "version=${{steps.version_branch_generate.outputs.CURRENT_VERSION}}" >> $GITHUB_OUTPUT
 #      - name: GitHub Tag Name example
 #        run: |
 #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
@@ -98,6 +105,13 @@ jobs:
     permissions: 
       contents: write
     steps:
+      - name: Set version from artifact
+        if: ${{env.artifact-version != ''}}
+        run: echo "version=${{env.artifact-version}}" >> $GITHUB_ENV
+      - name: Set version from tag
+        if: ${{env.tag-version != ''}}
+        run: echo "version=${{env.tag-version}}" >> $GITHUB_ENV
+        
       - uses: actions/checkout@v4
 
       - name: Add msbuild to PATH
@@ -116,7 +130,7 @@ jobs:
       - name: Create Artifacts
         uses: actions/upload-artifact@v4.3.6
         with:
-          name: 'HumbleKeysLibrary_${{env.artifact-version}}.pext'
+          name: 'HumbleKeysLibrary_${{env.version}}.pext'
           path: bin/Release/pext/HumbleKeysLibrary.pext
           if-no-files-found: 'error'
           overwrite: 'true'
@@ -125,13 +139,13 @@ jobs:
         id: download-artifact
         uses: actions/download-artifact@v4.1.8
         with: 
-          name: 'HumbleKeysLibrary_${{env.artifact-version}}.pext'
+          name: 'HumbleKeysLibrary_${{env.version}}.pext'
           path: 'artifacts'
       
       - name: Create Draft Release
         uses: softprops/action-gh-release@v2.0.8
         with: 
-          name: ${{env.artifact-version}}
+          name: ${{env.version}}
           body_path: changelog.md
           files: 'artifacts/*'
           draft: true

--- a/HumbleKeysLibrary.sln.DotSettings
+++ b/HumbleKeysLibrary.sln.DotSettings
@@ -15,4 +15,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gamekeys/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=humblebundle/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playnite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playnite/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unredeemable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/HumbleKeysLibrarySettings.cs
+++ b/HumbleKeysLibrarySettings.cs
@@ -20,6 +20,8 @@ namespace HumbleKeys
         public bool CacheEnabled { get; set; } = false;
         public string CurrentTagMethodology { get; set; } = "none";
 
+        public string CurrentUnredeemableMethodology { get; set; } = "tag";
+        
         [DontSerialize]
         public List<string> keyTypeWhitelist = new List<string>() {
             "gog",

--- a/HumbleKeysLibrarySettingsView.xaml
+++ b/HumbleKeysLibrarySettingsView.xaml
@@ -51,9 +51,36 @@
 				          ToolTip="When None is not selected, Humble Keys Library will add a new Tag per Bundle Name"
 				          Grid.Column="0"/>
 					<ListBox Margin="10 0 0 0 " Name="TagMethodology" SelectedValuePath="Tag" SelectedValue="{Binding CurrentTagMethodology, Mode=TwoWay}" Grid.Column="1" SelectionMode="Single">
+						
 						<ListBoxItem Tag="none" ToolTip="Do not create Tags based on Bundle Name">None</ListBoxItem>
-						<ListBoxItem Tag="monthly" ToolTip="Create only Tags for Humble Choice Monthly bundles" IsEnabled="{Binding IsChecked,ElementName=ImportChoiceKeys}">Monthly Only</ListBoxItem>
+						<ListBoxItem Tag="monthly" ToolTip="Create only Tags for Humble Choice Monthly bundles" IsEnabled="{Binding IsChecked,ElementName=ImportChoiceKeys}">
+							<ListBoxItem.Style>
+							<Style TargetType="{x:Type ListBoxItem}">
+								<Setter Property="Foreground" Value="White" />
+								<Style.Triggers>
+								</Style.Triggers>
+							</Style>
+						</ListBoxItem.Style>
+							Monthly Only
+						</ListBoxItem>
 						<ListBoxItem Tag="all" ToolTip="Create Tags for all Bundles">All</ListBoxItem>
+					</ListBox>
+				</Grid>
+			</StackPanel>
+			<StackPanel Margin="0 10 0 10" Width="Auto" Orientation="Horizontal">
+				<Grid Width="Auto">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"></ColumnDefinition>
+						<ColumnDefinition Width="Auto"></ColumnDefinition>
+					</Grid.ColumnDefinitions>
+					<TextBlock
+						Name="UnredeemableKeyHandling"
+						Text="Unredeemable key handling"
+						ToolTip="If Tag is selected, a new tag will replace the existing 'Key: Unredeemed' tag with 'Key: Unredeeemable'"
+						Grid.Column="0"/>
+					<ListBox Margin="10 0 0 0 " Name="UnredeemableKeyValues" SelectedValuePath="Tag" SelectedValue="{Binding CurrentUnredeemableMethodology, Mode=TwoWay}" Grid.Column="1" SelectionMode="Single" IsEnabled="{Binding IsChecked,ElementName=ImportChoiceKeys}">
+						<ListBoxItem Tag="tag" ToolTip="Create only Tags for Humble Choice Monthly bundles">Tag</ListBoxItem>
+						<ListBoxItem Tag="delete" ToolTip="Do not create Tags based on Bundle Name">Delete</ListBoxItem>
 					</ListBox>
 				</Grid>
 			</StackPanel>

--- a/Models/ChoiceMonthV2.cs
+++ b/Models/ChoiceMonthV2.cs
@@ -8,23 +8,46 @@ namespace HumbleKeys.Models
     {
         public class ContentChoiceOptions
         {
+            public class ContentChoicesMadeDataContainer
+            {
+                public class ContentChociesMadeData
+                {
+                    [SerializationPropertyName("choices_made")]
+                    public List<string> ChoicesMade;
+                }
+                [SerializationPropertyName("initial")]
+                public ContentChociesMadeData ChociesMadeData;
+
+                [SerializationPropertyName("initial-get-all-games")]
+                public ContentChociesMadeData ChociesMadeDataGetAllGames;
+            }
+
             public class ContentChoiceDataContainer
             {
                 public class ContentChoiceData
                 {
                     public Dictionary<string, ContentChoice> content_choices;
+                    [SerializationPropertyName("total_choices")]
+                    public int TotalChoices;
+                    [SerializationPropertyName("title")]
+                    public string Title;
                 }
                 [SerializationPropertyName("initial")]
                 public ContentChoiceData initial;
                 [SerializationPropertyName("initial-get-all-games")]
                 public ContentChoiceData initialGetAllGames;
+
+                public string Title => Data.Title;
+                public ContentChoiceData Data => initial ?? initialGetAllGames;
             }
+            [SerializationPropertyName("gamekey")]
+            public string gamekey;
 
-            public string gamekey { get; }
-
-            public string title { get; }
+            [SerializationPropertyName("title")]
+            public string title;
 
             public ContentChoiceDataContainer contentChoiceData;
+            public ContentChoicesMadeDataContainer contentChoicesMade;
         }
 
         public ContentChoiceOptions contentChoiceOptions;
@@ -32,6 +55,24 @@ namespace HumbleKeys.Models
         public string GameKey => contentChoiceOptions.gamekey;
 
         public string Title => contentChoiceOptions.title;
-        public List<ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.initial?.content_choices.Values.ToList()??contentChoiceOptions.contentChoiceData.initialGetAllGames.content_choices.Values.ToList();
+        public Dictionary<string,ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.initial?.content_choices??contentChoiceOptions.contentChoiceData.initialGetAllGames.content_choices;
+
+        public int TotalChoices => contentChoiceOptions.contentChoiceData.initial?.TotalChoices ??
+                                   contentChoiceOptions.contentChoiceData.initialGetAllGames.TotalChoices;
+        public List<string> ChoicesMade
+        {
+            get {
+                if (contentChoiceOptions.contentChoicesMade == null) return new List<string>();
+                if (contentChoiceOptions.contentChoicesMade.ChociesMadeDataGetAllGames != null)
+                {
+                    return contentChoiceOptions.contentChoicesMade.ChociesMadeDataGetAllGames.ChoicesMade;
+                }
+
+                return contentChoiceOptions.contentChoicesMade.ChociesMadeData != null ? contentChoiceOptions.contentChoicesMade.ChociesMadeData.ChoicesMade : new List<string>();
+            }
+        }
+
+        public bool ChoicesRemaining => ChoicesMade.Count < TotalChoices;
+
     }
 }

--- a/Models/ChoiceMonthV3.cs
+++ b/Models/ChoiceMonthV3.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Playnite.SDK.Data;
 
 namespace HumbleKeys.Models
 {
@@ -7,6 +8,20 @@ namespace HumbleKeys.Models
     {
         public class ContentChoiceOptions
         {
+            public class ContentChoicesMadeContainer
+            {
+                public class ContentChoicesContainer
+                {
+                    [SerializationPropertyName("choices_made")]
+                    public List<string> ChoicesMade;
+                }
+
+                [SerializationPropertyName("initial")]
+                public ContentChoicesContainer contentChoicesContainer;
+
+                public int TotalChoices;
+            }
+
             public class ContentChoiceDataContainer
             {
                 
@@ -18,11 +33,16 @@ namespace HumbleKeys.Models
             public string title { get; }
             
             public ContentChoiceDataContainer contentChoiceData;
+            public ContentChoicesMadeContainer contentChoicesMade;
         }
 
         public ContentChoiceOptions contentChoiceOptions;
         public string GameKey => contentChoiceOptions.gamekey;
         public string Title => contentChoiceOptions.title;
-        public List<ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.game_data.Values.ToList();
+        public Dictionary<string,ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.game_data;
+
+        public List<string> ChoicesMade => contentChoiceOptions.contentChoicesMade?.contentChoicesContainer?.ChoicesMade ?? new List<string>();
+
+        public bool ChoicesRemaining => ChoicesMade.Count == ContentChoices.Count;
     }
 }

--- a/Models/IChoiceMonth.cs
+++ b/Models/IChoiceMonth.cs
@@ -6,6 +6,10 @@ namespace HumbleKeys.Models
     {
         string GameKey { get; }
         string Title { get; }
-        List<ContentChoice> ContentChoices { get; }
+        Dictionary<string,ContentChoice> ContentChoices { get; }
+        
+        List<string> ChoicesMade { get; }
+        
+        bool ChoicesRemaining { get; }
     }
 }

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -65,6 +65,7 @@ namespace HumbleKeys.Models
                 public string steam_app_id;
                 public bool is_expired;
                 public Newtonsoft.Json.Linq.JToken redeemed_key_val;
+                public bool is_virtual = false;
             }
 
             public List<Tpk> all_tpks;
@@ -76,5 +77,11 @@ namespace HumbleKeys.Models
         public List<SubProduct> subproducts;
         public TpkdDict tpkd_dict;
         public List<string> path_ids;
+        // v3 seems to mean how many of the bundle has been selected
+        // v2 seems to mean number of games available to be redeemed
+        public int total_choices;
+        // v3 always 0?
+        // v2 total_choices - number of games redeemed
+        public int choices_remaining;
     }
 }


### PR DESCRIPTION
* Update Order model to determine virtual orders (items added from Bundle instead of from persisted record on server)
* Alter HumbleKeysAccountClient to add virtual orders that have not yet been added to the Order
* Add additional logic to HumbleKeysLibrary to handle unredeemable virtual orders (either exipred and cannot be redeemed or part of a Bundle where all choices have been made)
* Add new option to allow for either tagging a Game as 'Key: Unredeemable' or not add to the library