### PR TITLE
Store Added date in UTC format so comparitor can skip MetaData check …

### DIFF
--- a/HumbleKeysLibrary.cs
+++ b/HumbleKeysLibrary.cs
@@ -367,9 +367,10 @@ namespace HumbleKeys
         private bool UpdateMetaData(Game alreadyImported, Order sourceOrder, Order.TpkdDict.Tpk tpkd,
             Tag humbleChoiceTag)
         {
-            if (alreadyImported.Added == sourceOrder.created) return false;
+            var createdUtcDateTime = sourceOrder.created.ToUniversalTime();
+            if (alreadyImported.Added != null && alreadyImported.Added.Value == createdUtcDateTime) return false;
             
-            alreadyImported.Added = sourceOrder.created;
+            alreadyImported.Added = createdUtcDateTime;
             return true;
 
         } 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ## What's Changed
+# v0.3.7
+* [Bugfix] Notifications always displaying for tags updated due to DateCreated being not set as UTC
+
 # v0.3.6
 * [Bugfix] Game entries with empty notes were not getting the expiry note added
 


### PR DESCRIPTION
Notifications were triggering for every game imported due to Game.Added property being stored as DateTime.Kind = Unspecified