### PR TITLE
Manifests to be unix EOL format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 changelog.md text eol=lf
+Manifests/* text eol=lf

--- a/.github/workflows/generate_release_artifacts.yml
+++ b/.github/workflows/generate_release_artifacts.yml
@@ -284,7 +284,7 @@ jobs:
           cmd: |
             export CHANGELOG=`awk 'BEGIN {print "["}/^[\r]*$/{flag=1;next} /^# ${{env.next-version-short}}/{flag=1;next} /^# ${{env.current-version}}/{flag=0;exit} (firstline) {printf ","} flag {printf("\047%s\047",$0);firstline=1} END {print "]"}' changelog.md`
             yq -i '.Packages = [{
-            "Version":"${{env.version}}",
+            "Version":"${{env.next-version-short}}",
             "RequiredApiVersion":"${{steps.playnite_api_version.outputs.result}}",
             "ReleaseDate": (with_dtf("2025-12-01"; "${{steps.date.outputs.date}}") | from_json),
             "PackageUrl":"${{github.server_url}}/${{github.repository}}/releases/download/${{env.version}}/HumbleKeysLibrary_${{env.version}}.pext"


### PR DESCRIPTION
Toolbox verify only accepts Version format major.minor.build.revision instead of Semver major.minor.patch-prerelease