### PR TITLE
Fall back to Humble API when cached key value is missing, update DB o…

### DIFF
--- a/HumbleKeysLibrary/HumbleKeysLibrary.cs
+++ b/HumbleKeysLibrary/HumbleKeysLibrary.cs
@@ -84,14 +84,14 @@ namespace HumbleKeys
 
         public HumbleKeysLibrary(IPlayniteAPI api) : base(api)
         {
-            Properties = new LibraryPluginProperties { CanShutdownClient = false, HasCustomizedGameImport = true };
+            Properties = new LibraryPluginProperties { CanShutdownClient = false, HasCustomizedGameImport = true, HasSettings = true };
             var settings = new HumbleKeysLibrarySettings(this);
             Settings = settings;
         }
 
         public HumbleKeysLibrary(IPlayniteAPI api, HumbleKeysLibrarySettings settings) : base(api)
         {
-            Properties = new LibraryPluginProperties { CanShutdownClient = false, HasCustomizedGameImport = true };
+            Properties = new LibraryPluginProperties { CanShutdownClient = false, HasCustomizedGameImport = true, HasSettings = true };
             Settings = settings;
         }
 
@@ -102,6 +102,8 @@ namespace HumbleKeys
 
         public override UserControl GetSettingsView(bool firstRunSettings)
         {
+            var playniteDescription = this.PlayniteApi.Resources.GetString("LOCHumbleKeysCopyKeyMenuItem");
+            var Description = ResourceProvider.GetString("LOCHumbleKeysCopyKeyMenuItem");
             return new HumbleKeysLibrarySettingsView();
         }
 
@@ -172,7 +174,7 @@ namespace HumbleKeys
                 logger.Error($"Humble Keys Library: importError {dbImportMessageId}");
                 PlayniteApi.Notifications.Add(new NotificationMessage(
                     dbImportMessageId,
-                    string.Format(PlayniteApi.Resources.GetString("LOCLibraryImportError"), Name) +
+                    string.Format(ResourceProvider.GetString("LOCLibraryImportError"), Name) +
                     Environment.NewLine + importError.Message,
                     NotificationType.Error,
                     () => OpenSettingsView()));
@@ -569,6 +571,7 @@ namespace HumbleKeys
                 },
                 Tags = new HashSet<MetadataProperty>(),
                 Links = new List<Link>(),
+                
             };
 
             if (Settings.RedemptionStore != (int)RedemptionStoreType.Source)

--- a/HumbleKeysLibrary/HumbleKeysLibrary.csproj
+++ b/HumbleKeysLibrary/HumbleKeysLibrary.csproj
@@ -119,10 +119,11 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="Localization\en-US.xaml">
+    <Resource Include="Localization\en-US.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
-    </Page>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/HumbleKeysLibrary/Localization/en-US.xaml
+++ b/HumbleKeysLibrary/Localization/en-US.xaml
@@ -9,4 +9,7 @@
   <sys:String x:Key="LOCHumbleKeysRedemptionStoreTip">Add the store the key is for (e.g. Steam) to this field</sys:String>
   <sys:String x:Key="LOCHumbleKeysTagWithBundleTip">When None is not selected, Humble Keys Library will add a new Tag per Bundle Name</sys:String>
   <sys:String x:Key="LOCHumbleKeysUnredeemableKeyHandlingTip">If Tag is selected a new tag will replace the existing 'Key: Unredeemed' tag with 'Key: Unredeemable', if Delete is selected the game will be deleted from the library if it cannot be redeemed</sys:String>
+  <sys:String x:Key="LOCHumbleKeysCopyKeyMenuItem">Copy CD Key to Clipboard</sys:String>
+  <sys:String x:Key="LOCHumbleKeysCopyKeyNotInCache">CD key not found in local cache. Re-sync your library to populate the cache.</sys:String>
+  <sys:String x:Key="LOCHumbleKeysCopyKeyExhausted">CD key is not available. Humble Bundle may have removed the key value.</sys:String>
 </ResourceDictionary>

--- a/HumbleKeysLibrary/Services/GameKey/Models/Order.cs
+++ b/HumbleKeysLibrary/Services/GameKey/Models/Order.cs
@@ -48,7 +48,7 @@ namespace HumbleKeys.Services.GameKey.Models
                     visible = tpk.visible;
                 }
 
-                [PrimaryKey] [JsonIgnore] public int id { get; set; }
+                [PrimaryKey] [JsonIgnore] [AutoIncrement] public int id { get; set; }
 
                 [Indexed(Name = "TpkSecondaryKey", Order = 2, Unique = true)]
                 public string machine_name { get; set; }
@@ -130,7 +130,7 @@ namespace HumbleKeys.Services.GameKey.Models
                 this.persisted_all_tpks = new List<Tpk>();
                 for (var i = 0; i < persisted_all_tpks.all_tpks.Count; i++)
                 {
-                    this.persisted_all_tpks.Add(new Tpk(persisted_all_tpks.all_tpks.ElementAt(i)) {id = i});
+                    this.persisted_all_tpks.Add(new Tpk(persisted_all_tpks.all_tpks.ElementAt(i)));
                 }
             }
 

--- a/HumbleKeysLibrary/Services/HumbleOrderSqlRepository.cs
+++ b/HumbleKeysLibrary/Services/HumbleOrderSqlRepository.cs
@@ -89,13 +89,11 @@ namespace HumbleKeys.Services
 
         public bool Update(ITpk record)
         {
-            if (record is Models.Order.TpkdDict.Tpk)
-            {
-                // load record by primary key to update
-                var tpk = GetTpkById(new Order.TpkdDict.Tpk.TpkIdentifier
-                    { machine_name = record.machine_name, gamekey = record.gamekey });
-            }
-            return connection.Update(record, typeof(Order.TpkdDict.Tpk)) > 0;
+            var existing = GetTpkById(new Order.TpkdDict.Tpk.TpkIdentifier
+                { machine_name = record.machine_name, gamekey = record.gamekey });
+            if (existing == null) return false;
+            existing.redeemed_key_val = record.redeemed_key_val;
+            return connection.Update(existing) > 0;
         }
 
 


### PR DESCRIPTION
…n retrieval

Also fixes HumbleOrderSqlRepository.Update(ITpk) which was looking up the existing record by secondary key but then discarding it and updating by primary key (always 0 for API-fetched objects, silently updating nothing).